### PR TITLE
minor typo in sample code

### DIFF
--- a/tutorial/tcp-streams/index.html
+++ b/tutorial/tcp-streams/index.html
@@ -108,7 +108,7 @@ Sniffer sniffer = ...;
 
 // And start sniffing, forwarding all packets to our follower
 sniffer.sniff_loop([&](PDU& pdu) {
-    follower.process_packed(pdu);
+    follower.process_packet(pdu);
     return true;
 })
 {% endhighlight %}


### PR DESCRIPTION
Sample code should have read process_packe**t** instead of _process_packe**d**_.